### PR TITLE
Bs platform 2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "author": "CHEN Xian-an <xianan.chen@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "bs-platform": "^1.7.3"
+    "bs-platform": "^2.2.3"
+  },
+  "dependencies": {
+    "reason-cli": "^3.1.0-darwin",
+    "refmt": "^1.13.7-1"
   }
 }

--- a/src/webSockets.re
+++ b/src/webSockets.re
@@ -5,8 +5,8 @@ module MessageEvent = {
   [@bs.get] external stringData : t => string = "data";
   [@bs.get] external origin : t => string = "";
   [@bs.get] external lastEventId : t => string = "";
-  [@bs.get] external source : t => Js.t {..} = "";
-  [@bs.get] external ports : t => array (Js.t {..}) = "";
+  [@bs.get] external source : t => Js.t({.}) = "";
+  [@bs.get] external ports : t => array (Js.t({.})) = "";
 };
 
 module CloseEvent = {
@@ -25,7 +25,7 @@ module type WebSocketMaker = {
 module MakeWebSocket (Maker: WebSocketMaker) {
   type t = Maker.t;
   let make = Maker.make;
-  let makeWithProtocol = (url, ~protocol: string) => Maker.makeWithProtocols(url, ~protocols=list(protocol));
+  let makeWithProtocol = (url, ~protocol: string) => Maker.makeWithProtocols(url, ~protocols=[protocol]);
   let makeWithProtocols = (url, ~protocols: list(string)) => Maker.makeWithProtocols(url, ~protocols=(Array.of_list(protocols)));
   type binaryType =
     | Blob
@@ -53,7 +53,7 @@ module MakeWebSocket (Maker: WebSocketMaker) {
     | Error (string => unit)
     | Message (MessageEvent.t => unit)
     | Open (unit => unit);
-  [@bs.send.pipe : t] external _on : string => (Js.t => unit) => unit = "addEventListener";
+  [@bs.send.pipe : t] external _on : string => (Js.t({.}) => unit) => unit = "addEventListener";
   let on = (e, t) => {
     let evtname =
       switch e {
@@ -64,10 +64,10 @@ module MakeWebSocket (Maker: WebSocketMaker) {
       };
     _on(
       evtname,
-      ((jsobj) =>
+      ((jsobj: Js.t({.})) =>
           switch e {
           | Close(fn) => fn(Obj.magic(jsobj))
-          | Error(fn) => fn(jsobj##message)
+          | Error(fn) => fn(Obj.magic(jsobj))
           | Message(fn) => fn(Obj.magic(jsobj))
           | Open(fn) => fn()
           }

--- a/src/webSockets.re
+++ b/src/webSockets.re
@@ -1,114 +1,112 @@
 module MessageEvent = {
   type t;
-  external data : t => 'a = "" [@@bs.get];
-  external arrayBufferData : t => Js.Typed_array.array_buffer = "data" [@@bs.get];
-  external stringData : t => string = "data" [@@bs.get];
-  external origin : t => string = "" [@@bs.get];
-  external lastEventId : t => string = "" [@@bs.get];
-  external source : t => Js.t {..} = "" [@@bs.get];
-  external ports : t => array (Js.t {..}) = "" [@@bs.get];
+  [@bs.get] external data : t => 'a = "";
+  [@bs.get] external arrayBufferData : t => Js.Typed_array.array_buffer = "data";
+  [@bs.get] external stringData : t => string = "data";
+  [@bs.get] external origin : t => string = "";
+  [@bs.get] external lastEventId : t => string = "";
+  [@bs.get] external source : t => Js.t {..} = "";
+  [@bs.get] external ports : t => array (Js.t {..}) = "";
 };
 
 module CloseEvent = {
   type t;
-  external code : t => int = "" [@@bs.get];
-  external reason : t => string = "" [@@bs.get];
-  external wasClean : t => bool = "" [@@bs.get];
+  [@bs.get] external code : t => int = "";
+  [@bs.get] external reason : t => string = "";
+  [@bs.get] external wasClean : t => bool = "";
 };
 
 module type WebSocketMaker = {
   type t;
   let make: string => t;
-  let makeWithProtocols: string => protocols::'a => t;
+  let makeWithProtocols: (string, ~protocols :'a) => t;
 };
 
-module MakeWebSocket (Maker: WebSocketMaker) => {
+module MakeWebSocket (Maker: WebSocketMaker) {
   type t = Maker.t;
   let make = Maker.make;
-  let makeWithProtocol url protocol::(p: string) => Maker.makeWithProtocols url protocols::p;
-  let makeWithProtocols url protocols::(ps: list string) =>
-    Maker.makeWithProtocols url protocols::(Array.of_list ps);
+  let makeWithProtocol = (url, ~protocol: string) => Maker.makeWithProtocols(url, ~protocols=list(protocol));
+  let makeWithProtocols = (url, ~protocols: list(string)) => Maker.makeWithProtocols(url, ~protocols=(Array.of_list(protocols)));
   type binaryType =
     | Blob
     | ArrayBuffer;
-  external _binaryType : t => string = "binaryType" [@@bs.get];
-  external _setBinaryType : t => string => unit = "binaryType" [@@bs.set];
-  let binaryType t => {
-    let str = _binaryType t;
+  [@bs.get] external _binaryType : t => string = "binaryType";
+  [@bs.set] external _setBinaryType : t => string => unit = "binaryType";
+  let binaryType = t => {
+    let str = _binaryType(t);
     str == "blob" ? Blob : ArrayBuffer
   };
-  let setBinaryType binaryType t => {
+  let setBinaryType = (binaryType, t) => {
     let typestr =
       binaryType |> (
         fun
         | Blob => "blob"
         | ArrayBuffer => "arraybuffer"
       );
-    _setBinaryType t typestr;
+    _setBinaryType(t, typestr);
     t
   };
-  external bufferedAmount : t => int64 = "" [@@bs.get];
-  external extensions : t => 'a = "" [@@bs.get];
+  [@bs.get] external bufferedAmount : t => int64 = "";
+  [@bs.get] external extensions : t => 'a = "";
   type event =
     | Close (CloseEvent.t => unit)
     | Error (string => unit)
     | Message (MessageEvent.t => unit)
     | Open (unit => unit);
-  external _on : string => (Js.t {..} => unit) => unit = "addEventListener" [@@bs.send.pipe : t];
-  let on e t => {
+  [@bs.send.pipe : t] external _on : string => (Js.t => unit) => unit = "addEventListener";
+  let on = (e, t) => {
     let evtname =
       switch e {
-      | Close _ => "close"
-      | Error _ => "error"
-      | Message _ => "message"
-      | Open _ => "open"
+      | Close(_) => "close"
+      | Error(_) => "error"
+      | Message(_) => "message"
+      | Open(_) => "open"
       };
-    _on
-      evtname
-      (
-        fun jsobj =>
+    _on(
+      evtname,
+      ((jsobj) =>
           switch e {
-          | Close fn => fn @@ Obj.magic jsobj
-          | Error fn => fn jsobj##message
-          | Message fn => fn @@ Obj.magic jsobj
-          | Open fn => fn ()
+          | Close(fn) => fn(Obj.magic(jsobj))
+          | Error(fn) => fn(jsobj##message)
+          | Message(fn) => fn(Obj.magic(jsobj))
+          | Open(fn) => fn()
           }
-      )
-      t;
+      ),
+      t);
     t
   };
-  external protocol : t => string = "" [@@bs.get];
+  [@bs.get] external protocol : t => string = "";
   type readyState =
     | Connecting
     | Open
     | Closing
     | Closed;
-  external _readyState : t => int = "readyState" [@@bs.get];
-  let readyState t =>
-    switch (_readyState t) {
+  [@bs.get] external _readyState : t => int = "readyState";
+  let readyState = (t) =>
+    switch (_readyState(t)) {
     | 0 => Connecting
     | 1 => Open
     | 2 => Closing
     | _ => Closed
     };
-  external url : t => string = "" [@@bs.get];
-  external close : unit => unit = "" [@@bs.send.pipe : t];
-  external closeWithCode : int => unit = "close" [@@bs.send.pipe : t];
-  external closeWithReason : string => unit = "close" [@@bs.send.pipe : t];
-  external closeWithCodeAndReason : int => string => unit = "close" [@@bs.send.pipe : t];
-  external sendString : string => unit = "send" [@@bs.send.pipe : t];
-  external sendArrayBuffer : Js.Typed_array.array_buffer => unit = "send" [@@bs.send.pipe : t];
+  [@bs.get] external url : t => string = "";
+  [@bs.send.pipe : t] external close : unit => unit = "";
+  [@bs.send.pipe : t]external closeWithCode : int => unit = "close";
+  [@bs.send.pipe : t]external closeWithReason : string => unit = "close";
+  [@bs.send.pipe : t]external closeWithCodeAndReason : int => string => unit = "close";
+  [@bs.send.pipe : t]external sendString : string => unit = "send";
+  [@bs.send.pipe : t]external sendArrayBuffer : Js.Typed_array.array_buffer => unit = "send";
   type blob;
-  external sendBlob : blob => unit = "send" [@@bs.send.pipe : t];
+  [@bs.send.pipe : t] external sendBlob : blob => unit = "send";
 };
 
 module BrowserWebSocket = {
   type t;
-  external make : string => t = "WebSocket" [@@bs.new];
-  external makeWithProtocols : string => protocols::'a => t = "WebSocket" [@@bs.new];
+  [@bs.new] external make : string => t = "WebSocket";
+  [@bs.new] external makeWithProtocols: (string, ~protocols: 'a) => t = "WebSocket";
 };
 
-module WebSocket = MakeWebSocket BrowserWebSocket;
+module WebSocket = MakeWebSocket(BrowserWebSocket);
 /** Tips: If you need to make a WebSocket client on Nodejs, you can make a module to implement WebSocketMaker as BrowserWebSocket. e.g.
   *
   * WARNING: It's an untested example.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
-bs-platform@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-1.7.3.tgz#83de0134affdc723545477ce737606847da70104"
+bs-platform@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.3.tgz#d905ae10a5f3621e6a739041dfa0b58483a2174f"
+
+reason-cli@^3.1.0-darwin:
+  version "3.1.0-darwin"
+  resolved "https://registry.yarnpkg.com/reason-cli/-/reason-cli-3.1.0-darwin.tgz#88c32e6599f40a9fa94db29f9f182a37bff657d4"
+
+refmt@^1.13.7-1:
+  version "1.13.7-1"
+  resolved "https://registry.yarnpkg.com/refmt/-/refmt-1.13.7-1.tgz#c3159bcaf23b20cf2dc86cb161570792f62d1481"


### PR DESCRIPTION
Couldn't get bs-websockets working with a project on bs-platform 2+, so tried compiling on 2.2.3 directly, that failed, so this is the best I can do right now for upgrading the syntax.

I may have gotten the `Js.t {..}` and `##` conversions wrong since I can't find explicit doc on how the reason 2 syntax looked. (I assume the original here was reason 2)

Can't say I like the reason 3 syntax better, but when in rome.